### PR TITLE
Add Asciidoc Code Tags for Auth Docs

### DIFF
--- a/app/src/main/java/com/feedhenry/securenativeandroidtemplate/domain/Constants.java
+++ b/app/src/main/java/com/feedhenry/securenativeandroidtemplate/domain/Constants.java
@@ -17,7 +17,7 @@ public class Constants {
         public static final String IDENTITY_DATA = "identityData";
     }
 
-    public static final class KEYCLOAK_CONFIG {
+    public static final class OPEN_ID_CONNECT_CONFIG {
         public static final String BASE_SERVER_URI = "https://keycloak-openshift-mobile-security.osm1.skunkhenry.com/auth/realms/secure-app/protocol/openid-connect";
         public static final Uri AUTHORIZATION_ENDPOINT = Uri.parse(BASE_SERVER_URI + "/auth");
         public static final Uri TOKEN_ENDPOINT = Uri.parse(BASE_SERVER_URI + "/token");

--- a/app/src/main/java/com/feedhenry/securenativeandroidtemplate/features/authentication/providers/OpenIDAuthenticationProvider.java
+++ b/app/src/main/java/com/feedhenry/securenativeandroidtemplate/features/authentication/providers/OpenIDAuthenticationProvider.java
@@ -11,18 +11,29 @@ public interface OpenIDAuthenticationProvider {
 
         /**
          * Perform inital auth request to the auth endpoint
+         * @param fromActivity - the activity to use
+         * @param authCallback - the auth callback
          */
         public void performAuthRequest(Activity fromActivity, Callback authCallback);
 
         /**
          * Perform the logout flow
+         *
+         * @param logoutCallback - the logout callback
          */
         public void logout(Callback logoutCallback);
 
         /**
          * Used for check the authentication response from the browser
+         *
          * @param intent
          */
         public void onAuthResult(Intent intent);
 
+        /**
+         * Handles the initial auth response and create a new request to the token endpoint to get the actual tokens
+         *
+         * @param intent
+         */
+        public void handleAuthorizationResponse(Intent intent);
 }

--- a/app/src/main/java/com/feedhenry/securenativeandroidtemplate/mvp/components/AuthHelper.java
+++ b/app/src/main/java/com/feedhenry/securenativeandroidtemplate/mvp/components/AuthHelper.java
@@ -2,7 +2,6 @@ package com.feedhenry.securenativeandroidtemplate.mvp.components;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Base64;
 import android.util.Log;
@@ -34,6 +33,7 @@ public class AuthHelper {
         mPrefs = context.getSharedPreferences(STORE_NAME, MODE_PRIVATE);
     }
 
+    // tag::readAuthState[]
     /**
      * Read the auth state from shared preferences
      */
@@ -49,7 +49,9 @@ public class AuthHelper {
             return new AuthState();
         }
     }
+    // end::readAuthState[]
 
+    // tag::writeAuthState[]
     /**
      * Write the auth state to shared preferences
      * @param state - The Authstate to write to shared preferences
@@ -65,6 +67,7 @@ public class AuthHelper {
             }
         }
     }
+    // end::writeAuthState[]
 
     /**
      * Check if the user is authenticated/authorized
@@ -87,10 +90,11 @@ public class AuthHelper {
         return readAuthState().getIdToken();
     }
 
+    // tag::getIdentityInformation[]
     /**
      * Get the authenticated users identity information
      */
-    public static JSONObject getIdentityInfomation() {
+    public static JSONObject getIdentityInformation() {
         String accessToken = getAccessToken();
         JSONObject decodedIdentityData = new JSONObject();
 
@@ -110,6 +114,7 @@ public class AuthHelper {
         }
         return decodedIdentityData;
     }
+    // end::getIdentityInformation[]
 
     /**
      * Check if a new access token needs to be required
@@ -125,6 +130,7 @@ public class AuthHelper {
         readAuthState().setNeedsTokenRefresh(true);
     }
 
+    // tag::makeBearerRequest[]
     /**
      * Make a request to a resource that requires the access token to be sent with the request
      */
@@ -147,4 +153,5 @@ public class AuthHelper {
         call.enqueue(callback);
         return call;
     }
+    // end::makeBearerRequest[]
 }

--- a/app/src/main/java/com/feedhenry/securenativeandroidtemplate/navigation/Navigator.java
+++ b/app/src/main/java/com/feedhenry/securenativeandroidtemplate/navigation/Navigator.java
@@ -51,7 +51,7 @@ public class Navigator {
         if(AuthHelper.isAuthorized()) {
             Identity identity = null;
             try {
-                identity = Identity.fromJson(AuthHelper.getIdentityInfomation());
+                identity = Identity.fromJson(AuthHelper.getIdentityInformation());
             } catch (JSONException e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
**Description**
- Added AsciiDoc tags for Auth related Code/Methods (Using tags as referencing line numbers will quickly become un-maintainable as new code is added to each file)
- Fixed typo in function name
- Changed the Auth constants naming to use a generic OpenID Connect naming scheme instead of Keycloak 
- Add extra method to the OpenID Connect interface.