### PR TITLE
small ui improvements

### DIFF
--- a/app/src/main/java/com/feedhenry/securenativeandroidtemplate/features/authentication/AuthenticationFragment.java
+++ b/app/src/main/java/com/feedhenry/securenativeandroidtemplate/features/authentication/AuthenticationFragment.java
@@ -164,10 +164,13 @@ public class AuthenticationFragment extends BaseFragment<AuthenticationViewPrese
 
         AuthHelper.createRequest(hostURL, sendAccessToken, new okhttp3.Callback() {
             @Override
-            public void onFailure(Call call, IOException e) {
-                Log.w("Certificate Pinning", "Certificate Pinning Validation Failed", e);
+            public void onFailure(Call call, final IOException e) {
+
+                Snackbar.make(view, e.getMessage(), Snackbar.LENGTH_LONG)
+                        .show();
 
                 if (AuthHelper.checkCertificateVerificationError(e)) {
+                    Log.w("Certificate Pinning", "Certificate Pinning Validation Failed", e);
 
                     // run the UI updates on the UI thread
                     getActivity().runOnUiThread(new Runnable()
@@ -178,7 +181,7 @@ public class AuthenticationFragment extends BaseFragment<AuthenticationViewPrese
                             keycloakLogin.setVisibility(view.GONE);
 
                             // update the UI to state the connection is insecure
-                            authMessage.setText(R.string.insecure_connection);
+                            authMessage.setText(getString(R.string.cert_pin_verification_failed) + e.getMessage());
                             background.setImageResource(R.drawable.ic_error_background);
                             logo.setImageResource(R.drawable.ic_lock);
 

--- a/app/src/main/res/menu/menu_sidebar_content.xml
+++ b/app/src/main/res/menu/menu_sidebar_content.xml
@@ -28,17 +28,17 @@
             android:id="@+id/nav_device"
             android:icon="@drawable/ic_phone_lock"
             android:title="@string/fragment_title_device" />
-        <item
-            android:id="@+id/nav_cryptography"
-            android:icon="@drawable/ic_crypto"
-            android:title="@string/fragment_title_cryptography" />
-        <item
-            android:id="@+id/nav_memory"
-            android:icon="@drawable/ic_memory"
-            android:title="@string/fragment_title_memory" />
-        <item
-            android:id="@+id/nav_configuration"
-            android:icon="@drawable/ic_config"
-            android:title="@string/fragment_title_configuration" />
+        <!--<item-->
+            <!--android:id="@+id/nav_cryptography"-->
+            <!--android:icon="@drawable/ic_crypto"-->
+            <!--android:title="@string/fragment_title_cryptography" />-->
+        <!--<item-->
+            <!--android:id="@+id/nav_memory"-->
+            <!--android:icon="@drawable/ic_memory"-->
+            <!--android:title="@string/fragment_title_memory" />-->
+        <!--<item-->
+            <!--android:id="@+id/nav_configuration"-->
+            <!--android:icon="@drawable/ic_config"-->
+            <!--android:title="@string/fragment_title_configuration" />-->
     </group>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,12 +50,11 @@
     <string name="unknown_email">Unknown Email</string>
     <string name="unknown_name">Unknown Name</string>
     <string name="cert_pin_verification_failed">Certificate Pinning Verification Failed</string>
-    <string name="insecure_connection">Insecure Server Connection \n\nThe Servers Security Certificate is Not Trusted!</string>
     <string name="insecure_connection_prevent_auth">Insecure Server Connection. Preventing Authentication</string>
 
     <!-- Strings related to Access Control -->
     <string name="fragment_title_accesscontrol">Access Control</string>
-    <string name="not_authenticated">Insufficient Privileges</string>
+    <string name="not_authenticated">Insufficient Privileges. Your Access Token must possess the "mobile-user" realm role.</string>
     <string name="role_mobile_user_label">Mobile User Role</string>
     <string name="role_api_access_label">API Access Role</string>
     <string name="role_superuser_label">Superuser Role</string>

--- a/readme.adoc
+++ b/readme.adoc
@@ -1,6 +1,6 @@
 image:https://circleci.com/gh/feedhenry/mobile-security-android-template.svg?style=svg["CircleCI", link="https://circleci.com/gh/feedhenry/mobile-security-android-template"]
 image:https://img.shields.io/badge/API-19%2B-brightgreen.svg?style=flat["API", link="https://android-arsenal.com/api?level=19"]
-
+image:https://snyk.io/test/github/feedhenry/mobile-security-android-template/master%2Fapp/badge.svg?style=svg["Known Vulnerabilities", link="https://snyk.io/test/github/feedhenry/mobile-security-android-template/master%2Fapp"]
 
 = Secure Native Android Template
 
@@ -17,14 +17,3 @@ git checkout master
 git tag release-1.0.0 #change the release version based on the current release
 git push origin --tags
 ```
-
-== Dependency Check
-image:https://snyk.io/test/github/feedhenry/mobile-security-android-template/master%2Fapp/badge.svg?style=svg["Known Vulnerabilities", link="https://snyk.io/test/github/feedhenry/mobile-security-android-template/master%2Fapp"]
-
-The Apache HTTP client can be seen as both an API and an implementation. The OkHttp dependency doesn’t use the vulnerable implementation. 
-
-* SNYK-JAVA-ORGAPACHEHTTPCOMPONENTS-30647 (CVE-2015-5262)- Not Affected
-* SNYK-JAVA-ORGAPACHEHTTPCOMPONENTS-31517 (CWE-23) - Not Affected
-* SNYK-JAVA-ORGAPACHEHTTPCOMPONENTS-30645 (CVE-2012-6153) - Not Affected
-* SNYK-JAVA-ORGAPACHEHTTPCOMPONENTS-30644 (CVE-2011-1498) - Not Affected
-* SNYK-JAVA-ORGAPACHEHTTPCOMPONENTS-30646 (CVE-2014-3577) - Not Affected


### PR DESCRIPTION
- Improve Access Control Error Message to Show the Role Required to Access the View
- Improve Cert Pinning Error Messaging
- Comment out unused sidebar menu items
- Updated the vulnerable dependencies section in the readme. Snyk is no longer flagging the OkHttp vulnerabilities as an issue, so removed the explanation. Badge moved back to the top.