### PR TITLE
Update Pinned Cert Info

### DIFF
--- a/app/src/main/res/layout/fragment_authentication.xml
+++ b/app/src/main/res/layout/fragment_authentication.xml
@@ -30,8 +30,9 @@
         android:id="@+id/logo"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
         android:layout_centerHorizontal="true"
-        android:layout_centerVertical="true"
+        android:layout_marginTop="112dp"
         app:srcCompat="@drawable/ic_openid_connect" />
 
     <TextView
@@ -40,8 +41,9 @@
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         android:layout_centerHorizontal="true"
-        android:layout_marginBottom="150dp"
+        android:layout_marginTop="10dp"
         android:text=""
+        android:layout_below="@id/logo"
         android:textAlignment="center"
         android:textColor="#fff" />
 

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
     <domain-config cleartextTrafficPermitted="false">
-        <domain includeSubdomains="true">osm1.skunkhenry.com</domain>
+        <domain includeSubdomains="true">security.feedhenry.org</domain>
         <pin-set>
             // primary
-            <pin digest="SHA-256">jAoDAV3WG9IKcu0YJ1ZVTuEVqdcglfiQRqmfy3+ieoc=</pin>
+            <pin digest="SHA-256">trENjoQnbWupnAtu1/WagBE0RgJ+p7ke2ppWML8vAl0=</pin>
             // backup
-            <pin digest="SHA-256">XAoDAV3WG9IKcu0YJ1ZVTuEVqdcglfiQRqmfy3+ieoc=</pin>
+            <pin digest="SHA-256">arENjoQnbWupnAtu1/WagBE0RgJ+p7ke2ppWML8vAl0=</pin>
         </pin-set>
 
         // Set this to true for production, at least 2 unique pins must be provided above!
@@ -14,8 +14,6 @@
     </domain-config>
     <debug-overrides>
         <trust-anchors>
-            <!-- Trust preinstalled CAs -->
-            <certificates src="system" />
             <!-- Additionally trust user added CAs -->
             <certificates src="user" />
         </trust-anchors>


### PR DESCRIPTION
- Updated the pin to work with `security.feedhenry.org`
- Updated the UI to always display the cert error message under the image to prevent overlapping on long messages.
- Removed the `<certificates src="system" />`. This is preventing cert pinning from occurring, as it seems to override the cert pinning config defined above it. I tested the client cert auth with this change on API levels 26, 24 & 22 and it works fine. @wei-lee I remember that this had to be added when doing the client cert auth, can you verify that this is ok to be removed?