### PR TITLE
[WIP]  ⬆ use aerogear auth sdk

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,10 +2,10 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    buildToolsVersion '26.0.2'
     defaultConfig {
         applicationId "com.feedhenry.securenativeandroidtemplate"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -50,7 +50,8 @@ dependencies {
     compile 'com.android.support:design:25.3.1'
     compile 'com.android.support.constraint:constraint-layout:1.0.2'
     compile 'com.android.support:support-v4:25.3.1'
-    compile 'net.openid:appauth:0.7.0'
+    implementation 'org.aerogear:core:5.0.0-SNAPSHOT'
+    implementation 'org.aerogear:auth:5.0.0-SNAPSHOT'
     compile 'com.android.support:cardview-v7:25.3.1'
     compile 'com.squareup.okhttp3:okhttp:3.9.0'
     compile 'com.datatheorem.android.trustkit:trustkit:1.0.1@aar'

--- a/build.gradle
+++ b/build.gradle
@@ -2,19 +2,44 @@
 
 buildscript {
     repositories {
+        mavenLocal()
         jcenter()
+        google()
     }
+
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
 }
 
+plugins {
+    id "io.spring.dependency-management" version "1.0.4.RELEASE"
+}
+
+dependencyManagement {
+    imports {
+        mavenBom 'org.jboss.aerogear:aerogear-android-sdk-bom:1.1.10'
+    }
+}
+
 allprojects {
     repositories {
+        mavenLocal()
         jcenter()
+        google()
+    }
+}
+
+subprojects {
+    apply plugin: 'io.spring.dependency-management'
+
+    dependencyManagement {
+        imports {
+            mavenBom 'org.jboss.aerogear:aerogear-android-sdk-bom:1.1.10'
+        }
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Sep 01 20:28:02 IST 2017
+#Wed Feb 14 21:06:04 GMT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
Do not merge.

This PR will allow us to use aerogear auth module to perform authentication requests.

In order for this to work, please make sure the AG android sdk modules are installed locally. See https://github.com/aerogear/aerogear-android-sdk/pull/45.

ping @TommyJ1994 
