### PR TITLE
Update Proguard Rules

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -25,3 +25,4 @@
 #-renamesourcefileattribute SourceFile
 -dontwarn com.google.errorprone.annotations.*
 -dontwarn okio.**
+-dontwarn org.slf4j.**


### PR DESCRIPTION
Currently the `org.slf4j.**` classes don't support obfuscation and prevent signed binaries from being created. Updated the proguard rules to ignore obfuscating these classes.
https://github.com/getsentry/sentry-java/issues/373